### PR TITLE
Use latest rank parsers to fix gbif/parsers#35.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <!-- GBIF libraries -->
         <gbif-api.version>0.162</gbif-api.version>
         <dwc-api.version>1.35</dwc-api.version>
-        <gbif-parsers.version>0.57</gbif-parsers.version>
+        <gbif-parsers.version>0.60</gbif-parsers.version>
 
         <!-- Common libraries -->
         <apache.beam.version>2.17.0</apache.beam.version>


### PR DESCRIPTION
This mirrors the nub lookup fix on checklistbank https://github.com/gbif/checklistbank/commit/1f85c7b987fb5b114db23854fe51722c8401493f

