### PR TITLE
Tightens up caching policy and rank inference for specie match

### DIFF
--- a/kvs-gbif/src/main/java/org/gbif/kvs/species/SpeciesMatchRequest.java
+++ b/kvs-gbif/src/main/java/org/gbif/kvs/species/SpeciesMatchRequest.java
@@ -56,13 +56,13 @@ public class SpeciesMatchRequest implements Serializable, Indexable {
 
   @Override
   /**
-   * Returns a unique for the request that strictly respects the fields populated.
+   * Returns a unique key for the request that strictly respects the fields populated.
    */
   public String getLogicalKey() {
     return Stream.of(kingdom, phylum, clazz, order, family, genus, specificEpithet,
                             infraspecificEpithet, rank, verbatimTaxonRank, scientificName, genericName,
                             scientificNameAuthorship)
-            .map(s -> s == null ? "" : s).collect(Collectors.joining("|"));
+            .map(s -> s == null ? "" : s.trim()).collect(Collectors.joining("|"));
   }
 
   /**

--- a/kvs-gbif/src/main/java/org/gbif/kvs/species/SpeciesMatchRequest.java
+++ b/kvs-gbif/src/main/java/org/gbif/kvs/species/SpeciesMatchRequest.java
@@ -20,6 +20,8 @@ import org.gbif.kvs.hbase.Indexable;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.avro.reflect.Nullable;
 
@@ -53,18 +55,14 @@ public class SpeciesMatchRequest implements Serializable, Indexable {
   @Nullable private String scientificNameAuthorship;
 
   @Override
+  /**
+   * Returns a unique for the request that strictly respects the fields populated.
+   */
   public String getLogicalKey() {
-    return appendIgnoreNulls(kingdom, phylum, clazz, order, family, genus, specificEpithet,
+    return Stream.of(kingdom, phylum, clazz, order, family, genus, specificEpithet,
                             infraspecificEpithet, rank, verbatimTaxonRank, scientificName, genericName,
-                            scientificNameAuthorship);
-  }
-
-  private String appendIgnoreNulls(String... values) {
-    StringBuilder stringBuilder = new StringBuilder();
-    for (String value : values) {
-      Optional.ofNullable(value).map(String::trim).ifPresent(stringBuilder::append);
-    }
-    return stringBuilder.toString();
+                            scientificNameAuthorship)
+            .map(s -> s == null ? "" : s).collect(Collectors.joining("|"));
   }
 
   /**

--- a/kvs-gbif/src/main/java/org/gbif/kvs/species/TaxonParsers.java
+++ b/kvs-gbif/src/main/java/org/gbif/kvs/species/TaxonParsers.java
@@ -46,16 +46,6 @@ public class TaxonParsers {
     return Optional.ofNullable(rank);
   }
 
-  private static Rank fromFields(SpeciesMatchRequest speciesMatchRequest) {
-    if (speciesMatchRequest.getGenus() == null) {
-      return null;
-    }
-    if (speciesMatchRequest.getSpecificEpithet() == null) {
-      return Rank.GENUS;
-    }
-    return speciesMatchRequest.getInfraspecificEpithet() != null ? Rank.INFRASPECIFIC_NAME : Rank.SPECIES;
-  }
-
   @VisibleForTesting
   static String fromScientificName(String scientificName, String authorship) {
     boolean containsAuthorship =
@@ -82,9 +72,12 @@ public class TaxonParsers {
   }
 
 
+  /**
+   * Extract any stated rank from the request, but does not attempt to interpret it from the
+   * fields.
+   */
   public static Rank interpretRank(SpeciesMatchRequest speciesMatchRequest) {
-    return parserRank(speciesMatchRequest)
-            .orElseGet(() -> fromFields(speciesMatchRequest));
+    return parserRank(speciesMatchRequest).orElse(null);
   }
 
 

--- a/kvs-gbif/src/test/java/org/gbif/kvs/species/SpeciesMatchRequestTest.java
+++ b/kvs-gbif/src/test/java/org/gbif/kvs/species/SpeciesMatchRequestTest.java
@@ -1,0 +1,22 @@
+package org.gbif.kvs.species;
+
+import org.gbif.api.vocabulary.Rank;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class SpeciesMatchRequestTest {
+
+  @Test
+  public void testKey() {
+    assertEquals(
+            "Animalia||||||||species||Puma concolor||Tim Robertson 2023",
+            (SpeciesMatchRequest.builder()
+                    .withKingdom("Animalia")
+                    .withScientificName("Puma concolor")
+                    .withScientificNameAuthorship("Tim Robertson 2023")
+                    .withRank("species").build().getLogicalKey()));
+
+  }
+}

--- a/kvs-gbif/src/test/java/org/gbif/kvs/species/TaxonParsersTest.java
+++ b/kvs-gbif/src/test/java/org/gbif/kvs/species/TaxonParsersTest.java
@@ -1,10 +1,22 @@
 package org.gbif.kvs.species;
 
+import org.gbif.api.vocabulary.Rank;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class TaxonParsersTest {
+
+  @Test
+  public void requestExtractFromTest() {
+    assertEquals(
+            Rank.FAMILY,
+            TaxonParsers.interpretRank(SpeciesMatchRequest.builder().withRank("family").build()));
+
+    assertNull(
+            TaxonParsers.interpretRank(SpeciesMatchRequest.builder().withGenus("Aus").build()));
+  }
 
   @Test
   public void authorshipTest() {


### PR DESCRIPTION
This work is for https://github.com/gbif/pipelines/issues/921 